### PR TITLE
Fix HOST_UID/HOST_GID wiring in Make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Helper Makefile to simplify running the secure agent container
 # Usage: make run
 
-.PHONY: build run clean shell
+.PHONY: build run clean shell check-uid
 
 # Detect User ID and Group ID to prevent permission issues on Linux
 HOST_UID := $(shell id -u)
@@ -19,18 +19,35 @@ build:
 update:
 	docker compose build --no-cache
 
+# Export so docker compose (which reads HOST_UID/HOST_GID from the
+# environment via docker-compose.yml) picks them up consistently.
+export HOST_UID
+export HOST_GID
+
 # Run the agent in interactive mode
 # Passes the current user's UID/GID to the container
 run: setup
-	UID=$(HOST_UID) GID=$(HOST_GID) docker compose run --rm pi-agent
+	docker compose run --rm pi-agent
 
 # Run the agent with arguments (e.g., make args="--help" run-args)
 run-args: setup
-	UID=$(HOST_UID) GID=$(HOST_GID) docker compose run --rm pi-agent $(args)
+	docker compose run --rm pi-agent $(args)
 
 # Access the container shell for debugging
 shell: setup
-	UID=$(HOST_UID) GID=$(HOST_GID) docker compose run --entrypoint /bin/bash --rm pi-agent
+	docker compose run --entrypoint /bin/bash --rm pi-agent
+
+# Verify that the container actually runs as the host UID/GID.
+# Regression guard for the HOST_UID/HOST_GID wiring between the
+# Makefile and docker-compose.yml.
+check-uid: setup
+	@actual_uid=$$(docker compose run --rm --no-TTY --entrypoint id pi-agent -u); \
+	actual_gid=$$(docker compose run --rm --no-TTY --entrypoint id pi-agent -g); \
+	if [ "$$actual_uid" != "$(HOST_UID)" ] || [ "$$actual_gid" != "$(HOST_GID)" ]; then \
+		echo "FAIL: container uid:gid = $$actual_uid:$$actual_gid, expected $(HOST_UID):$(HOST_GID)"; \
+		exit 1; \
+	fi; \
+	echo "OK: container runs as $$actual_uid:$$actual_gid"
 
 # Clean up stopped containers and networks
 clean:


### PR DESCRIPTION
Fixes #2.

The Makefile previously exported `UID`/`GID` to docker compose, but `docker-compose.yml` reads `HOST_UID`/`HOST_GID`. That mismatch silently fell back to the `1000:1000` defaults, so on hosts where the caller is not `1000:1000` files written through the bind mount ended up owned by the wrong user.

### Changes

- Export `HOST_UID`/`HOST_GID` from the Makefile so `docker compose` picks them up via `docker-compose.yml`'s `${HOST_UID}`/`${HOST_GID}`.
- Drop the stray `UID=.../GID=...` prefixes from `run`, `run-args`, and `shell` — they never reached compose (`UID` is readonly in bash, which is why these vars were renamed to `HOST_*` in the first place).
- Add a `check-uid` target that runs `id -u` / `id -g` inside the container and fails if the effective UID/GID do not match the host. This is a regression guard for the wiring between the Makefile and compose file.

### Verification

```
make -n run
# => docker compose run --rm pi-agent
make check-uid
# => OK: container runs as <host-uid>:<host-gid>
```