### PR TITLE
fix(pie): only allocate a TTY when running interactively

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ pie --version
 
 `pie` calls `docker run` directly (bypassing Compose), reads `.env` from the pi-container repo automatically, and always sources `.pi-data` from there — so installed packages, settings, and login state are shared across all projects.
 
+`pie` auto-detects whether it is being run interactively: it passes `-i -t` to `docker run` only when both stdin and stdout are attached to a terminal, passes just `-i` when stdin is a pipe/file (so you can `echo ... | pie ...`), and omits both when run fully non-interactively (e.g. `pie --version` in CI). This keeps the interactive TUI working while making scripted use safe.
+
 ## Extending pi from inside the container
 
 Because mounts are read-write, pi can extend itself and changes persist:

--- a/pie
+++ b/pie
@@ -29,7 +29,18 @@ else
   echo "Warning: no .env file found in $SCRIPT_DIR — API keys / git identity may be missing." >&2
 fi
 
-docker run --rm -it \
+# Only allocate a TTY / attach stdin when both stdin and stdout are attached to
+# a terminal. This keeps the interactive TUI working while still allowing
+# scripted / CI use like `pie --version` or piping input.
+DOCKER_TTY_FLAGS=()
+if [ -t 0 ] && [ -t 1 ]; then
+  DOCKER_TTY_FLAGS+=(-i -t)
+elif [ ! -t 0 ]; then
+  # stdin is a pipe/file — keep it attached so data can flow in, but no TTY.
+  DOCKER_TTY_FLAGS+=(-i)
+fi
+
+docker run --rm ${DOCKER_TTY_FLAGS[@]+"${DOCKER_TTY_FLAGS[@]}"} \
   -e GITHUB_TOKEN \
   -e ANTHROPIC_API_KEY \
   -e OPENAI_API_KEY \


### PR DESCRIPTION
Closes #3.

## Problem

The `pie` wrapper always ran `docker run -it ...`, which is brittle in CI, scripts, and other non-interactive contexts. Things like `pie --version` or piping input into `pie` would fail with `the input device is not a TTY`.

## Change

Detect whether stdin/stdout are attached to a terminal and choose the right docker flags:

| stdin | stdout | flags passed to `docker run` |
|---|---|---|
| TTY | TTY | `-i -t` (interactive TUI, unchanged) |
| pipe/file | any | `-i` (data flows in, no TTY allocated) |
| TTY | non-TTY | none (safe for `pie --version` etc.) |

This preserves the interactive TUI while making scripted/CI use work.

## Test plan

- `pie` in a terminal → interactive TUI as before
- `pie --version` from a non-interactive context → no "input device is not a TTY" error
- `echo 'hello' | pie ...` → stdin is attached, no TTY allocated

Also updated README with a short note describing the auto-detection.