### PR TITLE
fix(pie): create .pi-data explicitly before bind-mounting

### DIFF
--- a/pie
+++ b/pie
@@ -29,6 +29,11 @@ else
   echo "Warning: no .env file found in $SCRIPT_DIR — API keys / git identity may be missing." >&2
 fi
 
+# Ensure the persistent pi data directory exists before docker bind-mounts it.
+# Otherwise Docker will auto-create it as root on some platforms, leading to
+# permission issues when the container runs as the host user.
+mkdir -p "$SCRIPT_DIR/.pi-data"
+
 # Only allocate a TTY / attach stdin when both stdin and stdout are attached to
 # a terminal. This keeps the interactive TUI working while still allowing
 # scripted / CI use like `pie --version` or piping input.


### PR DESCRIPTION
Closes #4

## Problem
The Makefile `setup` target creates `.pi-data`, but the `pie` wrapper bind-mounts `$SCRIPT_DIR/.pi-data` without creating it first. On fresh checkouts this depends on Docker's host-path auto-creation, whose ownership behavior varies by platform (often root-owned), which then conflicts with running the container as the host user.

## Fix
Add `mkdir -p "$SCRIPT_DIR/.pi-data"` in `pie` before the `docker run` invocation. This makes first-run behavior deterministic across environments and is a no-op when the directory already exists.

## Test
- Deleted `.pi-data` and ran `pie --version`; directory is created with correct host ownership before docker starts.
- Re-ran with existing `.pi-data`; no change in behavior.