### PR TITLE
fix(docker): pin uv and pi-coding-agent versions for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 # syntax=docker/dockerfile:1
 
+# -----------------------------------------------------------------------------
+# Pinned versions for reproducible builds.
+# Bump these deliberately; avoid `latest` so image contents don't drift.
+# -----------------------------------------------------------------------------
+ARG UV_VERSION=0.11.7
+ARG PI_AGENT_VERSION=0.67.68
+
 FROM node:22-bookworm-slim AS base
 
 # Set environment variables for production and non-interactive installation
@@ -37,16 +44,18 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
     && rm -rf /var/lib/apt/lists/*
 
 # -----------------------------------------------------------------------------
-# Install uv (fast Python package manager)
+# Install uv (fast Python package manager) at a pinned version
 # https://docs.astral.sh/uv/
 # -----------------------------------------------------------------------------
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+ARG UV_VERSION
+COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /uvx /usr/local/bin/
 
 FROM base AS release
 
-# Install the pi-coding-agent globally
+# Install the pi-coding-agent globally at a pinned version
 # We verify the registry connection implicitly during install
-RUN npm install -g @mariozechner/pi-coding-agent
+ARG PI_AGENT_VERSION
+RUN npm install -g @mariozechner/pi-coding-agent@${PI_AGENT_VERSION}
 
 # Transparently route GitHub SSH remotes over HTTPS so that `gh`'s credential
 # helper can authenticate pushes without requiring an ssh client or SSH keys.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A sandboxed Docker environment for running the [pi coding agent](https://github.
 - **pi coding agent**, **Python 3 + uv**, **Git + GitHub CLI**, and common build tools
 - Runs as a **non-root user** with **UID/GID mapping** so files stay owned by you
 - Only **explicit mounts** are exposed; skills are mounted **read-only**
-- **Built from source** — no pre-built images
+- **Builds locally** from a `Dockerfile` that installs **pinned** versions of `uv` and the pi agent from their upstream releases, so image contents don't drift between builds. Bump the `UV_VERSION` / `PI_AGENT_VERSION` args in the `Dockerfile` (or pass `--build-arg`) to upgrade.
 
 ## Quick start
 


### PR DESCRIPTION
Fixes #5.

## Problem
The Dockerfile pulled uv from `ghcr.io/astral-sh/uv:latest` and installed `@mariozechner/pi-coding-agent` without a version constraint. That made image contents drift across rebuilds and conflicted with the README's "Built from source" claim.

## Changes
- Added `UV_VERSION` and `PI_AGENT_VERSION` build args in the Dockerfile, defaulted to current upstream releases (`uv` 0.11.7, `pi-coding-agent` 0.67.68).
- `COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION}` and `npm install -g @mariozechner/pi-coding-agent@${PI_AGENT_VERSION}` now use those pinned versions.
- Updated the README's feature bullet to accurately describe the build (local build with pinned upstream releases) instead of implying a from-source build of the agent itself.

## Upgrading
Bump the `ARG` defaults at the top of the Dockerfile, or pass `--build-arg UV_VERSION=... --build-arg PI_AGENT_VERSION=...` to `docker build` / `make update`.